### PR TITLE
CI: rebuild lunr index

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -38,6 +38,7 @@ jobs:
             using Pkg; Pkg.activate("."); Pkg.instantiate();
             using NodeJS; run(`$(npm_cmd()) install highlight.js lunr cheerio`);
             using Franklin;
+            optimize();
             lunr();
             optimize()'
     - name: Build and Deploy

--- a/config.md
+++ b/config.md
@@ -1,6 +1,3 @@
-<!--
-Add here global page variables to use throughout your website.
--->
 +++
 author = "CDT AIMLAC"
 mintoclevel = 2
@@ -14,8 +11,10 @@ ignore = ["node_modules/"]
 
 # RSS (the website_{title, descr, url} must be defined to get RSS)
 generate_rss = true
+rss_full_content = false
+
 website_title = "AIMLAC Blogs"
-website_descr = "Example website using Franklin"
+website_descr = "Blogs for the AIMLAC center for doctoral training."
 website_url   = "cdt-aimlac.github.io/blogs"
 +++
 


### PR DESCRIPTION
Have to call `optimize` prior to calling `lunr`, else lunr will not parse any files. It seems one must then call `optimize` again (as is done here) to make sure the index is populated in the `__site` directory correctly.

