### PR TITLE
Site: tags

### DIFF
--- a/_css/custom.css
+++ b/_css/custom.css
@@ -7,8 +7,8 @@
 }
 
 .university-logo {
-    max-width: 20%;
-    padding: 16px !important;
+    max-width: 16%;
+    padding: 8px !important;
     vertical-align: middle;
 }
 

--- a/_layout/header.html
+++ b/_layout/header.html
@@ -1,6 +1,6 @@
 <header>
   <div class="blog-name">
-    <a href="/"><b>CDT AIMLAC Blogs</b></a>
+    <a href="/">CDT AIMLAC Blogs</a>
     <img src="/assets/AIMLAC-logo.png" id="aimlac-logo-header">
   </div>
 

--- a/_layout/page_foot.html
+++ b/_layout/page_foot.html
@@ -1,4 +1,4 @@
 <div class="page-foot">
-    <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> {{ fill author }}. {{isnotpage /tag/*}}Last modified: {{ fill fd_mtime }}.{{end}}
-    Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
+    <a href="http://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> CDT-AIMLAC. {{isnotpage /tag/*}} Page last modified: {{ fill fd_mtime }}.{{end}}
+    <br>Website built with <a href="https://github.com/tlienart/Franklin.jl">Franklin.jl</a> and the <a href="https://julialang.org">Julia programming language</a>.
 </div>

--- a/_layout/tag.html
+++ b/_layout/tag.html
@@ -1,6 +1,6 @@
 {{insert head.html}}
   <div class="franklin-content">
-    <h1>Tag: {{fill fd_tag}}</h1>
-    {{taglist}}
+    <h1>Posts tagged with <i>{{format_tag}}</i></h1>
+    {{postcard_taglist}}
   </div>
 {{insert foot.html}}

--- a/config.md
+++ b/config.md
@@ -19,4 +19,5 @@ website_url   = "cdt-aimlac.github.io/blogs"
 +++
 
 \newcommand{\maketitle}{{{maketitle}}}
+\newcommand{\addcomments}{{{addcomments}}}
 \newcommand{\example}[1]{@@example @@title Example @@ @@content #1 @@ @@}

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ title = "Home"
     
     <a href="http://www.bristol.ac.uk/homepage/"><img src="http://cdt-aimlac.org/images/logo-bristol.png" alt="" class="university-logo"></a>
 
-    <a href="https://www.cardiff.ac.uk/"><img src="http://cdt-aimlac.org/images/logo-cardiff.png" alt="" class="university-logo" style="max-width: 10%;"></a>
+    <a href="https://www.cardiff.ac.uk/"><img src="http://cdt-aimlac.org/images/logo-cardiff.png" alt="" class="university-logo" style="max-width: 7%;"></a>
 
     <a href="https://www.swansea.ac.uk/"><img src="http://cdt-aimlac.org/images/logo-swansea.png" alt="" class="university-logo"></a>
 

--- a/posts/fjebaker.welcome/main.md
+++ b/posts/fjebaker.welcome/main.md
@@ -135,3 +135,5 @@ To see examples of this, see the `posts` directory of any blog post in the [CDT-
 ## Licensing
 
 The source code and content of this repository is [MIT licensed](https://github.com/CDT-AIMLAC/blogs/blob/main/LICENSE), which extends itself to all posts on this site _unless the author_ specifies differently. In such cases, a `LICENSE` file will be included in the post directory to account for the author's wishes.
+
+\addcomments

--- a/posts/fjebaker.welcome/main.md
+++ b/posts/fjebaker.welcome/main.md
@@ -35,6 +35,14 @@ If you are a member of the AIMLAC CDT, you may wish to use this to
 
 Below are some technical details relating to the organization of the [GitHub repository](https://github.com/CDT-AIMLAC/blogs) where this site is kept, and also guides for contributing.
 
+## Features
+
+Blog posts may embed figures, datasets, execute arbitrary code at compile time or sandboxed scripts when live, feature rich interactive graphics, and much more!
+
+Each post has a creation and modification date, used to organize different chronological views when browsing posts. The blogs are also linked with _tags_, each of which is associated with a random color to aid a little with identifiability.
+
+More will be added when the site matures to help keep information navigable and accessible.
+
 ## Contributing
 
 The AIMLAC blogs are built using [Franklin.jl](https://franklinjl.org/), a feature-rich [static site](https://en.wikipedia.org/wiki/Static_web_page) generator, and the site itself is hosted using [GitHub pages](https://pages.github.com/). 

--- a/posts/tags.md
+++ b/posts/tags.md
@@ -4,5 +4,6 @@ title="All tags"
 
 # {{title}}
 
+Click on a tag to view all posts associated with that tag:
 
 {{all_tag_list}}

--- a/scripts/formatting.jl
+++ b/scripts/formatting.jl
@@ -25,3 +25,16 @@
     </div>
     """
 end
+
+@delay function hfun_addcomments()
+    return """
+    <script src="https://utteranc.es/client.js"
+        repo="https://github.com/CDT-AIMLAC/blogs"
+        issue-term="pathname"
+        label="comments"
+        theme="github-light"
+        crossorigin="anonymous"
+        async>
+    </script>
+    """
+end

--- a/scripts/parsers.jl
+++ b/scripts/parsers.jl
@@ -17,8 +17,7 @@ end
 
 Base.isless(p1::BlogPost, p2::BlogPost) = p1.date < p2.date
 
-function BlogPost(dir)
-    f = joinpath(dir, POSTS_MAIN)
+function BlogPost(f)
     author = pagevar(f, :author)
     affiliation = pagevar(f, :affiliation)
     title = pagevar(f, :title)
@@ -33,7 +32,7 @@ function BlogPost(dir)
 
     BlogPost(
         # trim off the `.md` extension
-        f[1:end-3], author, affiliation, title, summary, date, tags
+        f, author, affiliation, title, summary, date, tags
     )
 end
 
@@ -45,8 +44,13 @@ end
         files = readdir(d)
         POSTS_MAIN in files
     end
-    map(BlogPost, post_subdirs)
+    fs = joinpath.(post_subdirs, POSTS_MAIN)
+    # trim `.md` extension
+    fs = [i[1:end-3] for i in fs]
+    map(BlogPost, fs)
 end
+
+_get_posts_from_files(fs) = map(BlogPost, fs)
 
 function format_summary(b::BlogPost)
     date = Dates.format(b.date, "d u Y")

--- a/scripts/tags.jl
+++ b/scripts/tags.jl
@@ -5,8 +5,9 @@ Random.seed!(42)
 @memoize _tag_color(tag) = "#" * hex(HSV(floor(Int, rand() * 1000), 1, 1)) 
 
 function _get_all_tags()
-    posts = _get_posts()
-    reduce(vcat, map(i -> getproperty(i, :tags), posts)) |> unique |> sort
+    tags = [i[1] => length(i[2]) for i in globvar("fd_tag_pages")]
+    sort!(tags; by=last, rev=true)
+    tags
 end
 
 function format_tag(tag)
@@ -14,8 +15,26 @@ function format_tag(tag)
     """<a href="/tag/$tag"> $tag </a><div class="tag-color-box" style="background-color: $color;"></div>"""
 end
 
-function hfun_all_tag_list()
+@delay function hfun_all_tag_list()
     tags = _get_all_tags()
-    html_tags = ["<li> $i </li>" for i in format_tag.(tags)]
+    fmt_tags = [(format_tag(t), "$count post" * (count == 1 ? "" : "s")) for (t, count) in tags]
+    html_tags = ["<li> $(t) ($(count)) </li>" for (t, count) in fmt_tags]
     return "<ul>" * join(html_tags, "\n") * "</ul>"
+end
+
+function hfun_format_tag()
+    tag = locvar(:fd_tag)
+    return format_tag(tag)
+end
+
+# needed when building `tags.html`
+function hfun_postcard_taglist()
+    tag = locvar(:fd_tag)
+    rpaths = globvar("fd_tag_pages")[tag]
+    posts = _get_posts_from_files(rpaths)
+    sort!(posts; rev=true)
+
+    return join(
+        format_summary.(posts), "\n"
+    )
 end


### PR DESCRIPTION
Modified the tag preview pages to show postcards instead of just lists. The tag overview now also sorts tags by number of posts and lists how many posts are associated with each tag.

Minor modifications to header and footer of the website for more consistent feel of site. Also added small feature description to existing blog post.

Added the utterances comment system, but awaiting app approval from organisation (@colinsauze).